### PR TITLE
Added Unit Testing for Parsers, Memory, and Type Safety

### DIFF
--- a/BassClefStudio.DbLanguage.Core/Data/DataType.cs
+++ b/BassClefStudio.DbLanguage.Core/Data/DataType.cs
@@ -86,8 +86,7 @@ namespace BassClefStudio.DbLanguage.Core.Data
             }
 
             //// Get any DataContracts that are missing properties on the type.
-            BuildContainedTypes();
-            var unfulfilled = ContainedTypes.OfType<DataContract>().Where(c => !c.GetProperties().All(p => PublicProperties.Contains(p)));
+            var unfulfilled = InheritedContracts.Where(c => !c.GetProperties().All(p => PublicProperties.Contains(p)));
             if(unfulfilled.Any())
             {
                 throw new TypePropertyException($"One or more DataContracts are missing required properties on type {this.TypeName}: {string.Join(",", unfulfilled.Select(u => u.TypeName))}.");

--- a/BassClefStudio.DbLanguage.Core/Data/DataType.cs
+++ b/BassClefStudio.DbLanguage.Core/Data/DataType.cs
@@ -68,10 +68,13 @@ namespace BassClefStudio.DbLanguage.Core.Data
             PublicProperties = new List<MemoryProperty>();
             PrivateProperties = new List<MemoryProperty>();
 
-            PublicProperties.AddRange(ParentType.PublicProperties);
-            PublicProperties.AddRange(newPublic);
+            if(ParentType != null)
+            {
+                PublicProperties.AddRange(ParentType.PublicProperties);
+                PrivateProperties.AddRange(ParentType.PrivateProperties);
+            }
 
-            PrivateProperties.AddRange(ParentType.PrivateProperties);
+            PublicProperties.AddRange(newPublic);
             PrivateProperties.AddRange(newPrivate);
 
             //// Get any properties that have duplicate paths.
@@ -128,8 +131,11 @@ namespace BassClefStudio.DbLanguage.Core.Data
             {
                 ContainedTypes = new List<IType>();
                 ContainedTypes.AddRange(InheritedContracts);
-                ParentType.BuildContainedTypes();
-                ContainedTypes.AddRange(ParentType.ContainedTypes);
+                if (ParentType != null)
+                {
+                    ParentType.BuildContainedTypes();
+                    ContainedTypes.AddRange(ParentType.ContainedTypes);
+                }
             }
         }
 

--- a/BassClefStudio.DbLanguage.Core/Data/DataType.cs
+++ b/BassClefStudio.DbLanguage.Core/Data/DataType.cs
@@ -124,18 +124,20 @@ namespace BassClefStudio.DbLanguage.Core.Data
         #endregion
         #region Inheritance
 
-        private List<IType> ContainedTypes = null;
+        private IEnumerable<IType> ContainedTypes = null;
         private void BuildContainedTypes()
         {
             if (ContainedTypes == null)
             {
-                ContainedTypes = new List<IType>();
-                ContainedTypes.AddRange(InheritedContracts);
-                if (ParentType != null)
+                IEnumerable<IType> types;
+                types = (InheritedContracts as IEnumerable<IType>).Concat(new IType[] { this });
+                if(ParentType != null)
                 {
                     ParentType.BuildContainedTypes();
-                    ContainedTypes.AddRange(ParentType.ContainedTypes);
+                    types = types.Concat(ParentType.ContainedTypes);
                 }
+
+                ContainedTypes = types.Distinct();
             }
         }
 

--- a/BassClefStudio.DbLanguage.Core/Memory/MemoryProperty.cs
+++ b/BassClefStudio.DbLanguage.Core/Memory/MemoryProperty.cs
@@ -38,6 +38,10 @@ namespace BassClefStudio.DbLanguage.Core.Memory
         {
             Key = key;
             Type = type;
+            if (Type == null)
+            {
+                throw new ArgumentException("The type parameter of a MemoryProperty is required and cannot be null.");
+            }
             Flags = flags;
         }
 

--- a/BassClefStudio.DbLanguage.Tests/Core/MemoryUnitTests.cs
+++ b/BassClefStudio.DbLanguage.Tests/Core/MemoryUnitTests.cs
@@ -1,0 +1,57 @@
+﻿using BassClefStudio.DbLanguage.Core.Data;
+using BassClefStudio.DbLanguage.Core.Memory;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.DbLanguage.Tests.Core
+{
+    [TestClass]
+    public class MemoryUnitTests
+    {
+        public static IType TestType { get; set; }
+
+        [ClassInitialize]
+        public static void InitializeTestType(TestContext context)
+        {
+            // Creates a valid type for setting memory.
+            TestType = new DataType("TestType", typeof(string), new MemoryProperty[0], new MemoryProperty[0]);
+        }
+
+        #region Items
+
+        [TestMethod]
+        public void CreateProperty()
+        {
+            MemoryProperty property = new MemoryProperty("Prop", TestType);
+            Assert.IsTrue(property.Key == "Prop", "Property has incorrect name");
+            Assert.IsTrue(property.Type == TestType, "Property has incorrect datatype");
+        }
+
+        [TestMethod]
+        public void CreatePropertyNoType()
+        {
+            Assert.ThrowsException<ArgumentException>(() => new MemoryProperty("Prop", null));
+        }
+
+        [TestMethod]
+        public void CreateMemoryItem()
+        {
+            MemoryItem testItem = new MemoryItem(new MemoryProperty("Prop", TestType));
+            Assert.IsTrue(testItem.Value == null, "Value was not initialized to null.");
+        }
+
+        #endregion
+        #region Groups
+
+
+
+        #endregion
+        #region Stacks
+
+
+
+        #endregion
+    }
+}

--- a/BassClefStudio.DbLanguage.Tests/Core/MemoryUnitTests.cs
+++ b/BassClefStudio.DbLanguage.Tests/Core/MemoryUnitTests.cs
@@ -10,13 +10,17 @@ namespace BassClefStudio.DbLanguage.Tests.Core
     [TestClass]
     public class MemoryUnitTests
     {
-        public static IType TestType { get; set; }
+        public static DataType TestType { get; set; }
+        public static DataType AnotherTestType { get; set; }
+        public static DataType DerivedTestType { get; set; }
 
         [ClassInitialize]
         public static void InitializeTestType(TestContext context)
         {
-            // Creates a valid type for setting memory.
+            // Creates valid types for setting memory.
             TestType = new DataType("TestType", typeof(string), new MemoryProperty[0], new MemoryProperty[0]);
+            AnotherTestType = new DataType("OtherType", typeof(string), new MemoryProperty[0], new MemoryProperty[0]);
+            DerivedTestType = new DataType("DerivedType", typeof(string), new MemoryProperty[0], new MemoryProperty[0], null, TestType);
         }
 
         #region Items
@@ -40,6 +44,46 @@ namespace BassClefStudio.DbLanguage.Tests.Core
         {
             MemoryItem testItem = new MemoryItem(new MemoryProperty("Prop", TestType));
             Assert.IsTrue(testItem.Value == null, "Value was not initialized to null.");
+        }
+
+        [TestMethod]
+        public void CreateObject()
+        {
+            DataObject o = new DataObject(TestType);
+            Assert.IsTrue(o.DataType == TestType, "DataType type not set.");
+        }
+
+        [TestMethod]
+        public void TrySetTypeBinding()
+        {
+            DataObject o = new DataObject(TestType);
+            o.TrySetObject<string>("This is a test");
+            Assert.AreEqual("This is a test", o.GetObject<string>(), "Could not store and retreive bound object.");
+        }
+
+        [TestMethod]
+        public void InvalidTypeBinding()
+        {
+            DataObject o = new DataObject(TestType);
+            Assert.ThrowsException<TypeBindingException>(() => o.TrySetObject<int>(13));
+        }
+
+        [TestMethod]
+        public void SetMemoryItem()
+        {
+            MemoryItem testItem = new MemoryItem(new MemoryProperty("Prop", TestType));
+            var o = new DataObject(TestType);
+            Assert.IsTrue(testItem.Set(o), "Set operation failed.");
+            Assert.AreEqual(o, testItem.Value, "Value failed to store in memory.");
+        }
+
+        [TestMethod]
+        public void SetMemoryItemInvalidType()
+        {
+            MemoryItem testItem = new MemoryItem(new MemoryProperty("Prop", TestType));
+            var o = new DataObject(AnotherTestType);
+            Assert.IsFalse(testItem.Set(o), "Set operation should not have succeeded with incorrect type.");
+            Assert.AreNotEqual(o, testItem.Value, "Value was incorrectly stored in memory.");
         }
 
         #endregion

--- a/BassClefStudio.DbLanguage.Tests/Core/MemoryUnitTests.cs
+++ b/BassClefStudio.DbLanguage.Tests/Core/MemoryUnitTests.cs
@@ -47,28 +47,6 @@ namespace BassClefStudio.DbLanguage.Tests.Core
         }
 
         [TestMethod]
-        public void CreateObject()
-        {
-            DataObject o = new DataObject(TestType);
-            Assert.IsTrue(o.DataType == TestType, "DataType type not set.");
-        }
-
-        [TestMethod]
-        public void TrySetTypeBinding()
-        {
-            DataObject o = new DataObject(TestType);
-            o.TrySetObject<string>("This is a test");
-            Assert.AreEqual("This is a test", o.GetObject<string>(), "Could not store and retreive bound object.");
-        }
-
-        [TestMethod]
-        public void InvalidTypeBinding()
-        {
-            DataObject o = new DataObject(TestType);
-            Assert.ThrowsException<TypeBindingException>(() => o.TrySetObject<int>(13));
-        }
-
-        [TestMethod]
         public void SetMemoryItem()
         {
             MemoryItem testItem = new MemoryItem(new MemoryProperty("Prop", TestType));
@@ -89,7 +67,34 @@ namespace BassClefStudio.DbLanguage.Tests.Core
         #endregion
         #region Groups
 
+        [TestMethod]
+        public void DuplicateMemoryInGroup()
+        {
+            IWritableMemoryGroup testGroup = new MemoryGroup();
+            MemoryProperty prop = new MemoryProperty("Property", new DataType("TestType", new MemoryProperty[0], new MemoryProperty[0]));
+            MemoryItem i = new MemoryItem(prop);
+            Assert.IsTrue(testGroup.Add(i), "Failed to add item.");
+            Assert.IsFalse(testGroup.Add(i), "Duplicate was allowed to be added.");
+        }
 
+        [TestMethod]
+        public void DuplicatePropertyInGroup()
+        {
+            IWritableMemoryGroup testGroup = new MemoryGroup();
+            MemoryProperty prop = new MemoryProperty("Property", new DataType("TestType", new MemoryProperty[0], new MemoryProperty[0]));
+            Assert.IsTrue(testGroup.Add(new MemoryItem(prop)), "Failed to add item.");
+            Assert.IsFalse(testGroup.Add(new MemoryItem(prop)), "Duplicate property was allowed to be added.");
+        }
+
+        [TestMethod]
+        public void DuplicateNameInGroup()
+        {
+            IWritableMemoryGroup testGroup = new MemoryGroup();
+            MemoryProperty prop = new MemoryProperty("Property", new DataType("TestType", new MemoryProperty[0], new MemoryProperty[0]));
+            MemoryProperty prop2 = new MemoryProperty("Property", new DataType("TestType", new MemoryProperty[0], new MemoryProperty[0]));
+            Assert.IsTrue(testGroup.Add(new MemoryItem(prop)), "Failed to add item.");
+            Assert.IsFalse(testGroup.Add(new MemoryItem(prop2)), "Duplicate name was allowed to be added.");
+        }
 
         #endregion
         #region Stacks

--- a/BassClefStudio.DbLanguage.Tests/Core/TypeUnitTests.cs
+++ b/BassClefStudio.DbLanguage.Tests/Core/TypeUnitTests.cs
@@ -11,13 +11,83 @@ namespace BassClefStudio.DbLanguage.Tests.Core
     public class TypeUnitTests
     {
         [TestMethod]
+        public void InheritType()
+        {
+            DataType p = new DataType("ParentType", new MemoryProperty[0], new MemoryProperty[0]);
+            DataType t = new DataType("ChildType", new MemoryProperty[0], new MemoryProperty[0], parentType: p);
+            Assert.AreEqual(p, t.ParentType, "Child type does not inherit from parent type.");
+        }
+
+        [TestMethod]
+        public void InheritTypeWithProperty()
+        {
+            DataType propType = new DataType("PropType", new MemoryProperty[0], new MemoryProperty[0]);
+            MemoryProperty prop = new MemoryProperty("Prop", propType);
+            DataType p = new DataType("ParentType", new MemoryProperty[] { prop }, new MemoryProperty[0]);
+            DataType t = new DataType("ChildType", new MemoryProperty[0], new MemoryProperty[0], parentType: p);
+            Assert.AreEqual(p, t.ParentType, "Child type does not inherit from parent type.");
+            Assert.IsTrue(p.PublicProperties.Contains(prop), "Parent type does not contain property.");
+            Assert.IsTrue(t.PublicProperties.Contains(prop), "Child type does not contain property.");
+        }
+
+        [TestMethod]
         public void IsType()
         {
-            DataType t = new DataType("TestType", typeof(string), new MemoryProperty[0], new MemoryProperty[0]);
+            DataType t = new DataType("TestType", new MemoryProperty[0], new MemoryProperty[0]);
             Assert.IsTrue(t.Is(t), "Type IS not itself.");
-            DataType dT = new DataType("DerivedType", typeof(string), new MemoryProperty[0], new MemoryProperty[0], null, t);
-            Assert.IsTrue(dT.Is(t), "Derived type IS not parent.");
+            DataType dT = new DataType("DerivedType", new MemoryProperty[0], new MemoryProperty[0], null, t);
+            Assert.IsTrue(dT.Is(t), "Derived type IS not parent type.");
             Assert.IsFalse(t.Is(dT), "Parent type IS derived type.");
+        }
+
+        [TestMethod]
+        public void ImplementContract()
+        {
+            DataContract c = new DataContract("TestContract", new MemoryProperty[0], new DataContract[0]);
+            DataType t = new DataType("ChildType", new MemoryProperty[0], new MemoryProperty[0], new DataContract[] { c });
+            Assert.IsTrue(t.InheritedContracts.Contains(c), "Implementing type does not inherit from contract.");
+        }
+
+        [TestMethod]
+        public void ImplementContractWithProperty()
+        {
+            DataType propType = new DataType("PropType", new MemoryProperty[0], new MemoryProperty[0]);
+            MemoryProperty prop = new MemoryProperty("Prop", propType);
+            DataContract c = new DataContract("TestContract", new MemoryProperty[] { prop }, new DataContract[0]);
+            DataType t = new DataType("ChildType", new MemoryProperty[] { prop }, new MemoryProperty[0], new DataContract[] { c });
+            Assert.IsTrue(t.InheritedContracts.Contains(c), "Implementing type does not inherit from contract.");
+        }
+
+        [TestMethod]
+        public void MissingPropertyFromContract()
+        {
+            DataType propType = new DataType("PropType", new MemoryProperty[0], new MemoryProperty[0]);
+            MemoryProperty prop = new MemoryProperty("Prop", propType);
+            DataContract c = new DataContract("TestContract", new MemoryProperty[] { prop }, new DataContract[0]);
+            Assert.ThrowsException<TypePropertyException>(() => new DataType("ChildType", new MemoryProperty[0], new MemoryProperty[0], new DataContract[] { c }));
+        }
+
+        [TestMethod]
+        public void PrivatePropertyInContract()
+        {
+            DataType propType = new DataType("PropType", new MemoryProperty[0], new MemoryProperty[0]);
+            MemoryProperty prop = new MemoryProperty("Prop", propType);
+            DataContract c = new DataContract("TestContract", new MemoryProperty[] { prop }, new DataContract[0]);
+            Assert.ThrowsException<TypePropertyException>(() => new DataType("ChildType", new MemoryProperty[0], new MemoryProperty[] { prop }, new DataContract[] { c }));
+        }
+
+        [TestMethod]
+        public void IsContract()
+        {
+            DataContract c = new DataContract("TestContract", new MemoryProperty[0], new DataContract[0]);
+            Assert.IsTrue(c.Is(c), "Contract IS not itself.");
+            DataContract dC = new DataContract("DerivedContract", new MemoryProperty[0], new DataContract[] { c });
+            Assert.IsTrue(dC.Is(c), "Derived contract IS not parent contract.");
+            Assert.IsFalse(c.Is(dC), "Parent contract IS derived contract.");
+            DataType t = new DataType("TestType", typeof(string), new MemoryProperty[0], new MemoryProperty[0], new DataContract[] { dC });
+            Assert.IsTrue(t.Is(dC), "Implementing type IS not parent contract.");
+            Assert.IsTrue(t.Is(c), "Implementing type IS not parent contract's parent.");
+            Assert.IsFalse(dC.Is(t), "Contract IS implementing type.");
         }
     }
 }

--- a/BassClefStudio.DbLanguage.Tests/Core/TypeUnitTests.cs
+++ b/BassClefStudio.DbLanguage.Tests/Core/TypeUnitTests.cs
@@ -10,6 +10,8 @@ namespace BassClefStudio.DbLanguage.Tests.Core
     [TestClass]
     public class TypeUnitTests
     {
+        #region Inheritance
+
         [TestMethod]
         public void InheritType()
         {
@@ -59,6 +61,23 @@ namespace BassClefStudio.DbLanguage.Tests.Core
         }
 
         [TestMethod]
+        public void IsContract()
+        {
+            DataContract c = new DataContract("TestContract", new MemoryProperty[0], new DataContract[0]);
+            Assert.IsTrue(c.Is(c), "Contract IS not itself.");
+            DataContract dC = new DataContract("DerivedContract", new MemoryProperty[0], new DataContract[] { c });
+            Assert.IsTrue(dC.Is(c), "Derived contract IS not parent contract.");
+            Assert.IsFalse(c.Is(dC), "Parent contract IS derived contract.");
+            DataType t = new DataType("TestType", typeof(string), new MemoryProperty[0], new MemoryProperty[0], new DataContract[] { dC });
+            Assert.IsTrue(t.Is(dC), "Implementing type IS not parent contract.");
+            Assert.IsTrue(t.Is(c), "Implementing type IS not parent contract's parent.");
+            Assert.IsFalse(dC.Is(t), "Contract IS implementing type.");
+        }
+
+        #endregion
+        #region Properties
+
+        [TestMethod]
         public void MissingPropertyFromContract()
         {
             DataType propType = new DataType("PropType", new MemoryProperty[0], new MemoryProperty[0]);
@@ -77,17 +96,59 @@ namespace BassClefStudio.DbLanguage.Tests.Core
         }
 
         [TestMethod]
-        public void IsContract()
+        public void DuplicateProperty()
         {
-            DataContract c = new DataContract("TestContract", new MemoryProperty[0], new DataContract[0]);
-            Assert.IsTrue(c.Is(c), "Contract IS not itself.");
-            DataContract dC = new DataContract("DerivedContract", new MemoryProperty[0], new DataContract[] { c });
-            Assert.IsTrue(dC.Is(c), "Derived contract IS not parent contract.");
-            Assert.IsFalse(c.Is(dC), "Parent contract IS derived contract.");
-            DataType t = new DataType("TestType", typeof(string), new MemoryProperty[0], new MemoryProperty[0], new DataContract[] { dC });
-            Assert.IsTrue(t.Is(dC), "Implementing type IS not parent contract.");
-            Assert.IsTrue(t.Is(c), "Implementing type IS not parent contract's parent.");
-            Assert.IsFalse(dC.Is(t), "Contract IS implementing type.");
+            DataType propType = new DataType("PropType", new MemoryProperty[0], new MemoryProperty[0]);
+            MemoryProperty prop = new MemoryProperty("Prop", propType);
+            Assert.ThrowsException<TypePropertyException>(() => new DataType("ChildType", new MemoryProperty[] { prop, prop }, new MemoryProperty[0]));
         }
+
+        [TestMethod]
+        public void DuplicatePrivatePublicProperty()
+        {
+            DataType propType = new DataType("PropType", new MemoryProperty[0], new MemoryProperty[0]);
+            MemoryProperty prop = new MemoryProperty("Prop", propType);
+            Assert.ThrowsException<TypePropertyException>(() => new DataType("ChildType", new MemoryProperty[] { prop }, new MemoryProperty[] { prop }));
+        }
+
+        [TestMethod]
+        public void DuplicateNameProperty()
+        {
+            DataType propType = new DataType("PropType", new MemoryProperty[0], new MemoryProperty[0]);
+            DataType prop2Type = new DataType("Prop2Type", new MemoryProperty[0], new MemoryProperty[0]);
+            MemoryProperty prop = new MemoryProperty("Prop", propType);
+            MemoryProperty prop2 = new MemoryProperty("Prop", prop2Type);
+            Assert.ThrowsException<TypePropertyException>(() => new DataType("ChildType", new MemoryProperty[] { prop, prop2 }, new MemoryProperty[0]));
+        }
+
+        #endregion
+        #region Binding
+
+        [TestMethod]
+        public void CreateObject()
+        {
+            DataType propType = new DataType("PropType", typeof(string), new MemoryProperty[0], new MemoryProperty[0]);
+            DataObject o = new DataObject(propType);
+            Assert.IsTrue(o.DataType == propType, "DataType type not set.");
+        }
+
+        [TestMethod]
+        public void TrySetTypeBinding()
+        {
+            DataType propType = new DataType("PropType", typeof(string), new MemoryProperty[0], new MemoryProperty[0]);
+            DataObject o = new DataObject(propType);
+            o.TrySetObject<string>("This is a test");
+            Assert.AreEqual("This is a test", o.GetObject<string>(), "Could not store and retreive bound object.");
+        }
+
+        [TestMethod]
+        public void InvalidTypeBinding()
+        {
+            DataType propType = new DataType("PropType", typeof(string), new MemoryProperty[0], new MemoryProperty[0]);
+            DataObject o = new DataObject(propType);
+            Assert.ThrowsException<TypeBindingException>(() => o.TrySetObject<int>(13));
+        }
+
+        #endregion
     }
 }

--- a/BassClefStudio.DbLanguage.Tests/Core/TypeUnitTests.cs
+++ b/BassClefStudio.DbLanguage.Tests/Core/TypeUnitTests.cs
@@ -1,0 +1,23 @@
+﻿using BassClefStudio.DbLanguage.Core.Data;
+using BassClefStudio.DbLanguage.Core.Memory;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.DbLanguage.Tests.Core
+{
+    [TestClass]
+    public class TypeUnitTests
+    {
+        [TestMethod]
+        public void IsType()
+        {
+            DataType t = new DataType("TestType", typeof(string), new MemoryProperty[0], new MemoryProperty[0]);
+            Assert.IsTrue(t.Is(t), "Type IS not itself.");
+            DataType dT = new DataType("DerivedType", typeof(string), new MemoryProperty[0], new MemoryProperty[0], null, t);
+            Assert.IsTrue(dT.Is(t), "Derived type IS not parent.");
+            Assert.IsFalse(t.Is(dT), "Parent type IS derived type.");
+        }
+    }
+}

--- a/BassClefStudio.DbLanguage.Tests/Parse/CodeParseUnitTests.cs
+++ b/BassClefStudio.DbLanguage.Tests/Parse/CodeParseUnitTests.cs
@@ -77,7 +77,7 @@ namespace BassClefStudio.DbLanguage.Tests.Parse
             string methodName = "Test";
             string returnType = "void";
             var script = CreateScript($"private {returnType} {methodName}(){{}}");
-            Assert.IsTrue(!script.IsPublic, "Visibility is not private.");
+            Assert.IsFalse(script.IsPublic, "Visibility is not private.");
         }
 
         [TestMethod]
@@ -94,7 +94,7 @@ namespace BassClefStudio.DbLanguage.Tests.Parse
             string methodName = "Test";
             string returnType = "void";
             var script = CreateScript($"{returnType} {methodName}(){{}}");
-            Assert.IsTrue(!script.IsPublic, "Visibility is not private.");
+            Assert.IsFalse(script.IsPublic, "Visibility is not private.");
         }
 
         [TestMethod]

--- a/BassClefStudio.DbLanguage.Tests/Parse/TypeHeaderParseUnitTests.cs
+++ b/BassClefStudio.DbLanguage.Tests/Parse/TypeHeaderParseUnitTests.cs
@@ -47,7 +47,7 @@ namespace BassClefStudio.DbLanguage.Tests.Parse
         public void CheckTypeContractParse()
         {
             string code = "contract Blah {}";
-            Assert.IsTrue(!Parser.ParseClass(code).Header.IsConcrete);
+            Assert.IsFalse(Parser.ParseClass(code).Header.IsConcrete);
         }
 
         [TestMethod]


### PR DESCRIPTION
This is all part of the `BassClefStudio.DbLanguage.Tests` project, which currently contains 58 tests, all of which the project have passed (these edits **INCLUDE** bug fixes that affected the results of tests added to the project).