### PR TITLE
Update push.yml

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - master
     paths:
-    - '**.nuspec'
+    - '**.csproj'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Push.yml in .NET Standard/Core projects updated to trigger on .csproj edit, not .nuspec edit (older project types).